### PR TITLE
feat(default): Update default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        "group:allNonMajor"
     ],
     "labels": ["dependencies"],
     "reviewersFromCodeOwners": true,
@@ -9,18 +10,5 @@
     "vulnerabilityAlerts": {
         "enabled": true,
         "labels": ["security"]
-    },
-    "packageRules": [{
-            "matchUpdateTypes": ["major"],
-            "labels": ["major", "breaking-change"]
-        },
-        {
-            "matchUpdateTypes": ["minor"],
-            "labels": ["minor", "dependencies"]
-        },
-        {
-            "matchUpdateTypes": ["patch"],
-            "labels": ["patch", "dependencies"]
-        }
-    ]
+    }
 }


### PR DESCRIPTION
Change:
Use renovate default group:allNonMajor preset, which is **almost** the same as the packageRules configuration

More info:
https://docs.renovatebot.com/presets-group/#groupallnonmajor 